### PR TITLE
Update and Copy landnode.ks to landlongnode.ks.

### DIFF
--- a/script/landlongnode.ks
+++ b/script/landlongnode.ks
@@ -1,17 +1,30 @@
-declare parameter peri.
+// Longitude specific version of landnode.ks, with adjustments for body rotation whilst cruising to node and descending from node.
+
+declare parameter peri is lorb/2.	// peri = altitude to begin descent from.
+declare parameter DeorbitLongitude IS 42.	// 47 degrees sets Kerbin directly overhead, but the lander takes about 5 degrees to land.
+
+SET DeorbitSpot TO LATLNG(0, DeorbitLongitude).
+set pSpot to DeorbitSpot:position - body:position.
+set aSpot to arctan2(pSpot:x,pSpot:z).
+
 // descent orbit insertion
 // prerequisite: ship in circular orbit
 // move origin to central body (i.e. Mun)
 set pship to V(0,0,0) - body:position.
 set psun to sun:position - body:position.
+
 // current target angular position 
 set aship to arctan2(pship:x,pship:z).
 set asun to arctan2(psun:x,psun:z).
+
 // target angular position after transfer
 set sma to pship:mag.                       // mun/minmus have a circular orbit
 set ops to 2 * pi * sqrt(sma^3/mu).         // mun/minmus orbital period
 // aim for landing zone 60 degrees before sunset
 set aperi to asun - 30.                     // assume counterclockwise orbits
+
+set aperi to aSpot.
+
 // ship angular position for maneuver
 set as0 to mod(aperi + 180, 360).
 print "T+" + round(missiontime) + " Ship, orbital period: " + round(ops/60,1) + "m".
@@ -35,3 +48,13 @@ print "T+" + round(missiontime) + " Descent orbit burn: " + round(vom) + ", dv:"
 set nd to node(time:seconds + etam, 0, 0, deltav).
 add nd.
 
+// adjust for the body we are orbiting to rotate under us whilst we cruise to the descending node.
+set shiptonodedegrees to 360 * etam / body:rotationperiod.
+set adjustforshiptonodeseconds to ops * shiptonodedegrees / 360.
+// adjust for the body we are orbiting to rotate during the descent to periapsis to land with "run landv(3)." after the node is created.
+set adjustfororbitdegrees to 360 * (nd:orbit:period / 2) / body:rotationperiod.	
+set adjustfororbitseconds to ops * adjustfororbitdegrees / 360.
+
+remove nd.
+set nd to node(time:seconds + etam + adjustforshiptonodeseconds + adjustfororbitseconds, 0, 0, deltav).
+add nd.

--- a/script/landlongnode.ks
+++ b/script/landlongnode.ks
@@ -50,10 +50,10 @@ add nd.
 
 // adjust for the body we are orbiting to rotate under us whilst we cruise to the descending node.
 set shiptonodedegrees to 360 * etam / body:rotationperiod.
-set adjustforshiptonodeseconds to ops * shiptonodedegrees / 360.
+set adjustforshiptonodeseconds to sin(90 - ABS(ORBIT:INCLINATION)) * ops * shiptonodedegrees / 360.
 // adjust for the body we are orbiting to rotate during the descent to periapsis to land with "run landv(3)." after the node is created.
 set adjustfororbitdegrees to 360 * (nd:orbit:period / 2) / body:rotationperiod.	
-set adjustfororbitseconds to ops * adjustfororbitdegrees / 360.
+set adjustfororbitseconds to sin(90 - ABS(nd:ORBIT:INCLINATION)) * ops * adjustfororbitdegrees / 360.
 
 remove nd.
 set nd to node(time:seconds + etam + adjustforshiptonodeseconds + adjustfororbitseconds, 0, 0, deltav).


### PR DESCRIPTION
I tried to use landnode.ks to land at a particular longitude every time (instead of in relation to where the sun was), but the new periapsis kept moving.
I realized the Mun was rotating whilst the ship cruised up to the node and also whilst the ship descended to the new periapsis after the node was created.
ah ha! Lines 51 through 60 make the corrections! I have left the original sun-angle code in. One could write some soft of if-then based on the parameters input so this code could do either "land before sunset" or "land at specified longitude"... p.s. thank you for all this code. It is wonderful.
